### PR TITLE
PR: Enable caching/memoization for repositories created by generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"typescript": "^3.8.3"
 	},
 	"dependencies": {
-		"@sparkwave/standard": "^2.3.1",
+		"@sparkwave/standard": "^2.5.0",
 		"@types/shortid": "0.0.29",
 		"shortid": "^2.2.15"
 	}

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
 		"typescript": "^3.8.3"
 	},
 	"dependencies": {
+		"@sparkwave/standard": "^2.3.1",
 		"@types/shortid": "0.0.29",
-		"shortid": "^2.2.15",
-		"standard": "git+https://github.com/Hypothesize/standard.git"
+		"shortid": "^2.2.15"
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 import { generate, Repository, RepositoryEditable, RepositoryReadonly, RepositoryGroup } from './repository'
-import { DTOsMap, IOProvider } from './types'
+import { DTOsMap, IOProvider, CacheEntry } from './types'
 
-export { generate, IOProvider, Repository, RepositoryEditable, RepositoryReadonly, RepositoryGroup, DTOsMap }
+export { generate, IOProvider, Repository, RepositoryEditable, RepositoryReadonly, RepositoryGroup, DTOsMap, CacheEntry }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -40,7 +40,16 @@ export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOP
 		}
 		protected createRepository<E extends Extract<keyof D, string>>(e: E) {
 			return {
-				findAsync: async (id: string) => this.io.findAsync({ entity: e, id: id }),
+				findAsync: async (id: string) => {
+					if (this.io.cache) {
+						if (this.io.cache[id] === undefined) {
+							this.io.cache[id] === this.io.findAsync({ entity: e, id: id })
+						}
+						return this.io.cache[id]
+					} else {
+						return this.io.findAsync({ entity: e, id: id })
+					}
+				},
 				getAsync: async (selector?: { parentId?: string, filters?: FilterGroup<D[E]["fromStorage"]> }) => {
 					return this.io.getAsync({ entity: e, parentId: selector?.parentId, filters: selector?.filters })
 				},

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -13,8 +13,8 @@ export interface RepositoryEditable<D extends DTOsMap, E extends keyof D> extend
 	saveAsync: (obj: D[E]["toStorage"][]) => Promise<D[E]["fromStorage"][]>
 }
 export interface Repository<D extends DTOsMap, E extends keyof D> extends RepositoryEditable<D, E> {
-	deleteAsync: (id: string) => Promise<void>
-	deleteManyAsync?: (args: { parentId: string } | { ids: string[] }) => Promise<void>
+	deleteAsync: (id: string) => Promise<D[E]["fromStorage"]>
+	deleteManyAsync?: (args: { parentId: string } | { ids: string[] }) => Promise<D[E]["fromStorage"][]>
 }
 export type RepositoryGroup<D extends DTOsMap> = { [key in keyof D]: Repository<D, Extract<keyof D, string>> }
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,7 +1,8 @@
 
-import { DTOsMap, IOProvider, Ctor, FilterGroup, CacheEntry } from "./types"
+import { FilterGroup } from "@sparkwave/standard"
+import { DTOsMap, IOProvider, Ctor, CacheEntry } from "./types"
 
-export interface RepositoryReadonly<D extends DTOsMap, E extends keyof D> {
+export interface RepositoryReadonly<D extends DTOsMap, E extends Extract<keyof D, "string">> {
 	/** find one entity object with a specific id, throws exception if not found */
 	findAsync(id: string): Promise<D[E]["fromStorage"]>
 
@@ -12,28 +13,28 @@ export interface RepositoryReadonly<D extends DTOsMap, E extends keyof D> {
 	/** A method to remove an entry from the cache */
 	bustCache?(entry: CacheEntry<D>): () => void
 }
-export interface RepositoryEditable<D extends DTOsMap, E extends keyof D> extends RepositoryReadonly<D, E> {
+export interface RepositoryEditable<D extends DTOsMap, E extends Extract<keyof D, "string">> extends RepositoryReadonly<D, E> {
 	saveAsync: (obj: D[E]["toStorage"][]) => Promise<D[E]["fromStorage"][]>
 }
-export interface Repository<D extends DTOsMap, E extends keyof D> extends RepositoryEditable<D, E> {
+export interface Repository<D extends DTOsMap, E extends Extract<keyof D, "string">> extends RepositoryEditable<D, E> {
 	deleteAsync: (id: string) => Promise<D[E]["fromStorage"]>
 	deleteManyAsync?: (args: { parentId: string } | { ids: string[] }) => Promise<D[E]["fromStorage"][]>
 }
 export type RepositoryGroup<D extends DTOsMap> = {
-	[key in keyof D]: Repository<D, Extract<keyof D, string>>
+	[key in Extract<keyof D, "string">]: Repository<D, Extract<keyof D, "string">>
 } & { cache?: CacheEntry<D>[] }
 
-/**
- * 
+/** Generates a repository group from the io provider
  * @param ioProviderClass 
  * @param repos The individual repositories: tables, users...
  */
-export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoNames: Extract<keyof D, string>[], cache?: CacheEntry<D>[]) => RepositoryGroup<D> {
+export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoNames: (Extract<keyof D, "string">)[], cache?: CacheEntry<D>[]) => RepositoryGroup<D> {
 	return class {
+		[key: string]: any
 		readonly io: Readonly<IOProvider<X>>
 		cache?: CacheEntry<D>[]
 
-		constructor(config: object, dtoNames: Extract<keyof D, string>[], cache?: CacheEntry<D>[]) {
+		constructor(config: object, dtoNames: (Extract<keyof D, "string">)[], cache?: CacheEntry<D>[]) {
 			try {
 				this.io = new ioProviderClass({ ...config, cache: cache })
 				this.cache = cache
@@ -46,36 +47,36 @@ export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOP
 				this[prop as string] = this.createRepository(prop, this.cache) as Repository<D, typeof prop>
 			})
 		}
-		protected createRepository<E extends Extract<keyof D, string>>(e: E, cache: CacheEntry<D>[]) {
+		protected createRepository<E extends Extract<keyof D, "string">>(e: E, cache?: CacheEntry<D>[]) {
 			return {
 				findAsync: async (id: string) => {
-					if (this.cache) {
-						if (this.cache.find(entry => entry.type === "find" && entry.key === id) === undefined) {
-							this.cache.push({ type: "find", key: id, content: this.io.findAsync({ entity: e, id: id }) })
+					if (this.cache !== undefined) {
+						if (this.cache.find(entry => entry.type === "single" && entry.key === id) === undefined) {
+							this.cache.push({ type: "single", key: id, content: this.io.findAsync({ entity: e, id: id }) })
 						}
-						return this.cache.find(entry => entry.type === "find" && entry.key === id).content
+						return this.cache.find(entry => entry.type === "single" && entry.key === id)?.content
 					} else {
 						return this.io.findAsync({ entity: e, id: id })
 					}
 				},
-				getAsync: async (selector?: { parentId?: string, filters?: FilterGroup<D[E]["fromStorage"]> }) => {
+				getAsync: async (selector: { parentId?: string, filters?: FilterGroup<D[E]["fromStorage"]> }) => {
 					if (this.cache) {
-						if (this.cache.find(entry => entry.type === "get"
+						if (this.cache.find(entry => entry.type === "multiple"
 							&& entry.keys.entity === e
 							&& entry.keys.parentId === selector.parentId
 							&& entry.keys.filters === JSON.stringify(selector.filters)
 						) === undefined) {
 							this.cache.push({
-								type: "get",
-								keys: { entity: e, parentId: selector.parentId, filters: JSON.stringify(selector.filters) },
+								type: "multiple",
+								keys: { entity: e, parentId: selector.parentId || "", filters: JSON.stringify(selector.filters) },
 								content: this.io.getAsync({ entity: e, parentId: selector?.parentId, filters: selector?.filters })
 							})
 						}
-						return this.cache.find(entry => entry.type === "get"
+						return this.cache.find(entry => entry.type === "multiple"
 							&& entry.keys.entity === e
 							&& entry.keys.parentId === selector.parentId
 							&& entry.keys.filters === JSON.stringify(selector.filters)
-						).content
+						)?.content
 					}
 					else {
 						return this.io.getAsync({ entity: e, parentId: selector?.parentId, filters: selector?.filters })
@@ -86,13 +87,15 @@ export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOP
 						? this.io.saveAsync({ entity: e, obj: obj, mode: "update" })
 						: this.io.saveAsync({ entity: e, obj: obj, mode: "insert" })
 				},
-				deleteAsync: async (id: string) => this.io.deleteAsync({ entity: e, id }),
-				deleteManyAsync: async (args: { parentId: string } | { ids: string[] }) => this.io.deleteManyAsync({
-					entity: e,
-					...args["parentId"] !== undefined
-						? { parentId: args["parentId"] }
-						: { ids: args["ids"] }
-				}),
+				deleteAsync: async (id: string) => this.io.deleteAsync({ entity: e, id: id }),
+				deleteManyAsync: async (args: { parentId: string } | { ids: string[] }) => this.io.deleteManyAsync
+					? this.io.deleteManyAsync({
+						entity: e,
+						..."parentId" in args
+							? { parentId: args["parentId"] }
+							: { ids: args["ids"] }
+					})
+					: undefined,
 				cache: cache
 			} as Repository<D, E>
 		}

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -48,7 +48,7 @@ export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOP
 						if (this.cache.find(entry => entry.type === "find" && entry.key === id) === undefined) {
 							this.cache.push({ type: "find", key: id, content: this.io.findAsync({ entity: e, id: id }) })
 						}
-						return this.cache.find(entry => entry.type === "find" && entry.key === id)
+						return this.cache.find(entry => entry.type === "find" && entry.key === id).content
 					} else {
 						return this.io.findAsync({ entity: e, id: id })
 					}
@@ -70,7 +70,7 @@ export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOP
 							&& entry.keys.entity === e
 							&& entry.keys.parentId === selector.parentId
 							&& entry.keys.filters === JSON.stringify(selector.filters)
-						)
+						).content
 					}
 					else {
 						return this.io.getAsync({ entity: e, parentId: selector?.parentId, filters: selector?.filters })

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -45,7 +45,7 @@ export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOP
 				findAsync: async (id: string) => {
 					if (this.cache) {
 						if (this.cache[id] === undefined) {
-							this.cache[id] === this.io.findAsync({ entity: e, id: id })
+							this.cache[id] = this.io.findAsync({ entity: e, id: id })
 						}
 						return this.cache[id]
 					} else {
@@ -56,7 +56,7 @@ export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOP
 					if (this.cache) {
 						const args = JSON.stringify(selector)
 						if (this.cache[args] === undefined) {
-							this.cache[args] === this.io.getAsync({ entity: e, parentId: selector?.parentId, filters: selector?.filters })
+							this.cache[args] = this.io.getAsync({ entity: e, parentId: selector?.parentId, filters: selector?.filters })
 						}
 						return this.cache[args]
 					}

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -21,19 +21,19 @@ export interface Repository<D extends DTOsMap, E extends keyof D> extends Reposi
 }
 export type RepositoryGroup<D extends DTOsMap> = {
 	[key in keyof D]: Repository<D, Extract<keyof D, string>>
-} & { cache: CacheEntry<D>[] }
+} & { cache?: CacheEntry<D>[] }
 
 /**
  * 
  * @param ioProviderClass 
  * @param repos The individual repositories: tables, users...
  */
-export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoNames: Extract<keyof D, string>[], cache: CacheEntry<D>[]) => RepositoryGroup<D> {
+export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoNames: Extract<keyof D, string>[], cache?: CacheEntry<D>[]) => RepositoryGroup<D> {
 	return class {
 		readonly io: Readonly<IOProvider<X>>
 		cache?: CacheEntry<D>[]
 
-		constructor(config: object, dtoNames: Extract<keyof D, string>[], cache: CacheEntry<D>[]) {
+		constructor(config: object, dtoNames: Extract<keyof D, string>[], cache?: CacheEntry<D>[]) {
 			try {
 				this.io = new ioProviderClass({ ...config, cache: cache })
 				this.cache = cache

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -22,7 +22,7 @@ export type RepositoryGroup<D extends DTOsMap> = { [key in keyof D]: Repository<
  * @param ioProviderClass 
  * @param repos The individual repositories: tables, users...
  */
-export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoNames: Extract<keyof D, string>[]) => RepositoryGroup<D> {
+export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoNames: Extract<keyof D, string>[], cache?: boolean) => RepositoryGroup<D> {
 	return class {
 		readonly io: Readonly<IOProvider<X>>
 		readonly cache?: { [key: string]: D[Extract<keyof D, string>]["fromStorage"] | D[Extract<keyof D, string>]["fromStorage"][] }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -76,23 +76,6 @@ export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOP
 						return this.io.getAsync({ entity: e, parentId: selector?.parentId, filters: selector?.filters })
 					}
 				},
-				bustCache: (entry: CacheEntry<D>) => {
-					if (this.cache) {
-						if (entry.type === "find") {
-							this.cache = this.cache.filter(async el => {
-								return el !== entry
-							})
-						}
-						else {
-							this.cache = this.cache.filter(async el => {
-								return !(el.type === "get"
-									&& el.keys.entity === entry.keys.entity
-									&& el.keys.parentId === entry.keys.parentId
-									&& el.keys.filters === entry.keys.filters)
-							})
-						}
-					}
-				},
 				saveAsync: async (obj: D[E]["toStorage"][]) => {
 					return obj[0].id
 						? this.io.saveAsync({ entity: e, obj: obj, mode: "update" })

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -54,7 +54,7 @@ export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOP
 				},
 				getAsync: async (selector?: { parentId?: string, filters?: FilterGroup<D[E]["fromStorage"]> }) => {
 					if (this.cache) {
-						const args = JSON.stringify(selector)
+						const args = JSON.stringify({ entity: e, selector: selector })
 						if (this.cache[args] === undefined) {
 							this.cache[args] = this.io.getAsync({ entity: e, parentId: selector?.parentId, filters: selector?.filters })
 						}

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,7 +15,7 @@ export type CacheEntry<D extends DTOsMap> = {
 	content?: Promise<D[Extract<keyof D, string>]["fromStorage"]>
 } | {
 	type: "get"
-	keys: { entity: Extract<keyof D, string>, parentId: string, filters: string },
+	keys: { entity: Extract<keyof D, string>, parentId: string, filters?: string },
 	content?: Promise<D[Extract<keyof D, string>]["fromStorage"][]>
 }
 export interface IOProvider<X = {}, D extends DTOsMap = DTOsMap> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,36 +1,39 @@
-export type Obj<TValue = any, TKey extends string = string> = { [key in TKey]: TValue }
-export type ExtractByType<TObj, TType> = Pick<TObj, { [k in keyof TObj]-?: TObj[k] extends TType ? k : never }[keyof TObj]>
-export type Primitive = number | string
+import { ExtractByType, Obj, Primitive, FilterGroup } from "@sparkwave/standard"
 
 export interface Ctor<TArgs = {}, TObj = {}> { new(args: TArgs): TObj }
 
 type DTO = {
-	toStorage: Object & { id?: string }
-	fromStorage: Object
+	toStorage: Obj<Primitive> & { id?: string }
+	fromStorage: Obj<Primitive>
 }
 export type DTOsMap = { [key: string]: DTO }
-export type CacheEntry<D extends DTOsMap> = {
-	type: "find"
-	key: string,
-	content?: Promise<D[Extract<keyof D, string>]["fromStorage"]>
-} | {
-	type: "get"
-	keys: { entity: Extract<keyof D, string>, parentId: string, filters?: string },
-	content?: Promise<D[Extract<keyof D, string>]["fromStorage"][]>
-}
+
+export type CacheEntry<D extends DTOsMap> = (
+	| {
+		type: "single"
+		key: string,
+		content?: Promise<D[keyof D]["fromStorage"]>
+	}
+	| {
+		type: "multiple"
+		keys: { entity: keyof D, parentId: string, filters?: string },
+		content?: Promise<D[keyof D]["fromStorage"][]>
+	}
+)
+
 export interface IOProvider<X = {}, D extends DTOsMap = DTOsMap> {
 	/** find one entity object, throws exception if not found */
-	findAsync: <E extends Extract<keyof D, string>>(args: { entity: E, id: string }) => Promise<D[E]["fromStorage"]>
+	findAsync: <E extends keyof D>(args: { entity: E, id: string }) => Promise<D[E]["fromStorage"]>
 
 	/** get a set of entity objects */
-	getAsync: <E extends Extract<keyof D, string>>(args: { entity: E, parentId?: string, filters?: FilterGroup<D[E]["fromStorage"]> }) => Promise<D[E]["fromStorage"][]>
-	saveAsync: <E extends Extract<keyof D, string>>(args: {
+	getAsync: <E extends keyof D>(args: { entity: E, parentId?: string, filters?: FilterGroup<D[E]["fromStorage"]> }) => Promise<D[E]["fromStorage"][]>
+	saveAsync: <E extends keyof D>(args: {
 		entity: E,
 		obj: D[E]["toStorage"][],
 		mode: "insert" | "update"
 	}) => Promise<D[E]["fromStorage"][]>
-	deleteAsync: <E extends Extract<keyof D, string>>(args: { entity: E, id: string }) => Promise<D[E]["fromStorage"]>
-	deleteManyAsync?: <E extends Extract<keyof D, string>>(args: { entity: E } & { ids: string[] } | { parentId: string }) => Promise<D[E]["fromStorage"][]>
+	deleteAsync: <E extends keyof D>(args: { entity: E, id: string }) => Promise<D[E]["fromStorage"]>
+	deleteManyAsync?: <E extends keyof D>(args: { entity: E } & ({ ids: string[] } | { parentId: string })) => Promise<D[E]["fromStorage"][]>
 	extensions: X
 }
 
@@ -55,17 +58,4 @@ export namespace Filters {
 		/** number of std. deviations (possibly fractional) */
 		//value: number
 	}
-}
-type Filter<T extends Obj<Primitive> = Obj<Primitive>> = (
-	| Filters.Categorical<T>
-	| Filters.Ordinal<T>
-	| Filters.Textual<T>
-	| Filters.Statistical<T>
-)
-
-export interface FilterGroup<T extends Obj = Obj> {
-	/** combinator default is "and" */
-	combinator?: "or" | "and",
-
-	filters: (Filter<T> | FilterGroup<T>)[]
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,11 +12,11 @@ export type DTOsMap = { [key: string]: DTO }
 export type CacheEntry<D extends DTOsMap> = {
 	type: "find"
 	key: string,
-	content: Promise<D[Extract<keyof D, string>]["fromStorage"]>
+	content?: Promise<D[Extract<keyof D, string>]["fromStorage"]>
 } | {
 	type: "get"
 	keys: { entity: Extract<keyof D, string>, parentId: string, filters: string },
-	content: Promise<D[Extract<keyof D, string>]["fromStorage"][]>
+	content?: Promise<D[Extract<keyof D, string>]["fromStorage"][]>
 }
 export interface IOProvider<X = {}, D extends DTOsMap = DTOsMap> {
 	/** find one entity object, throws exception if not found */

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,6 @@ export interface IOProvider<X = {}, D extends DTOsMap = DTOsMap> {
 
 	/** get a set of entity objects */
 	getAsync: <E extends Extract<keyof D, string>>(args: { entity: E, parentId?: string, filters?: FilterGroup<D[E]["fromStorage"]> }) => Promise<D[E]["fromStorage"][]>
-	bustCache: (entry: CacheEntry<D>) => void
 	saveAsync: <E extends Extract<keyof D, string>>(args: {
 		entity: E,
 		obj: D[E]["toStorage"][],

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,8 +29,8 @@ export interface IOProvider<X = {}, D extends DTOsMap = DTOsMap> {
 		obj: D[E]["toStorage"][],
 		mode: "insert" | "update"
 	}) => Promise<D[E]["fromStorage"][]>
-	deleteAsync: <E extends Extract<keyof D, string>>(args: { entity: E, id: string }) => Promise<void>
-	deleteManyAsync?: <E extends Extract<keyof D, string>>(args: { entity: E } & { ids: string[] } | { parentId: string }) => Promise<void>
+	deleteAsync: <E extends Extract<keyof D, string>>(args: { entity: E, id: string }) => Promise<D[E]["fromStorage"]>
+	deleteManyAsync?: <E extends Extract<keyof D, string>>(args: { entity: E } & { ids: string[] } | { parentId: string }) => Promise<D[E]["fromStorage"][]>
 	extensions: X
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,14 +9,22 @@ type DTO = {
 	fromStorage: Object
 }
 export type DTOsMap = { [key: string]: DTO }
-
+export type CacheEntry<D extends DTOsMap> = {
+	type: "find"
+	key: string,
+	content: Promise<D[Extract<keyof D, string>]["fromStorage"]>
+} | {
+	type: "get"
+	keys: { entity: Extract<keyof D, string>, parentId: string, filters: string },
+	content: Promise<D[Extract<keyof D, string>]["fromStorage"][]>
+}
 export interface IOProvider<X = {}, D extends DTOsMap = DTOsMap> {
 	/** find one entity object, throws exception if not found */
 	findAsync: <E extends Extract<keyof D, string>>(args: { entity: E, id: string }) => Promise<D[E]["fromStorage"]>
 
 	/** get a set of entity objects */
 	getAsync: <E extends Extract<keyof D, string>>(args: { entity: E, parentId?: string, filters?: FilterGroup<D[E]["fromStorage"]> }) => Promise<D[E]["fromStorage"][]>
-
+	bustCache: (entry: CacheEntry<D>) => void
 	saveAsync: <E extends Extract<keyof D, string>>(args: {
 		entity: E,
 		obj: D[E]["toStorage"][],

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,6 @@ export interface IOProvider<X = {}, D extends DTOsMap = DTOsMap> {
 	}) => Promise<D[E]["fromStorage"][]>
 	deleteAsync: <E extends Extract<keyof D, string>>(args: { entity: E, id: string }) => Promise<void>
 	deleteManyAsync?: <E extends Extract<keyof D, string>>(args: { entity: E } & { ids: string[] } | { parentId: string }) => Promise<void>
-	cache?: { [key: string]: Promise<D[Extract<keyof D, string>]["fromStorage"]> }
 	extensions: X
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export interface IOProvider<X = {}, D extends DTOsMap = DTOsMap> {
 	}) => Promise<D[E]["fromStorage"][]>
 	deleteAsync: <E extends Extract<keyof D, string>>(args: { entity: E, id: string }) => Promise<void>
 	deleteManyAsync?: <E extends Extract<keyof D, string>>(args: { entity: E } & { ids: string[] } | { parentId: string }) => Promise<void>
-
+	cache?: { [key: string]: Promise<D[Extract<keyof D, string>]["fromStorage"]> }
 	extensions: X
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,10 @@
 		"target": "es2015",
 		"module": "commonjs",
 		"declaration": true,
-		"outDir": "./dist"
+		"outDir": "./dist",
+		"strictNullChecks": true,
+		"strict": true,
+		"incremental": true
 	},
 	"types": "dist/index.d.ts",
 	"include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,20 +2,27 @@
 	"compilerOptions": {
 		"target": "es2015",
 		"module": "commonjs",
+		"moduleResolution": "node",
+		"traceResolution": false,
 		"declaration": true,
-		"outDir": "./dist",
-		"strictNullChecks": true,
+		"lib": [
+			"es7",
+			"es6",
+			"es5",
+			"dom",
+			"es2015.promise",
+			"scripthost",
+			"dom.iterable",
+			"esnext.asynciterable"
+		],
 		"strict": true,
-		"incremental": true
+		"strictNullChecks": true,
+		"skipLibCheck": true,
+		"incremental": true,
+		"outDir": "./dist"
 	},
-	"types": "dist/index.d.ts",
 	"include": [
-		"src",
-		"src/types/index.d.ts",
-		"src/types.d.ts"
+		"./src",
 	],
-	"exclude": [
-		"node_modules",
-		"**/__tests__/*"
-	]
+	"exclude": []
 }


### PR DESCRIPTION
Resolves #21 

**Merge message:**
- Added an optional cache object to the repositories created by the generator, from which "findAsync" and "getAsync" requests will pick data if it is available.
- Changed the return type of deleteAsync and deleteManyAsync, to make them return the deleted entities instead of nothing.