### PR TITLE
PR: Update and improve cache system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # repository.ts
 Database access through the repository pattern in Javascript/TypeScript
+
+# Cache system
+If the option is enabled, a cache object will be created along with the repository group.
+It stores the return values of calls to "getAsync" and "findAsync" functions, to return it faster when the same calls are made afterwards.
+### Entries insertion
+A call to "findAsync" creates a "single" type cache entry, which stores a single entity.
+A call to "getAsync" creates a "multiple" cache entry, which stores all entities returned by the function.
+### Entries invalidation
+**Automatic**
+When the saveAsync and deleteAsync functions are called, all cache entries related to the updated entity will be removed: its "single" type entry if present, and any "multiple" entries that included it in the results.
+**Manual**
+In addition, every repository exposes a "bustCache" function: it should be used to invalidate the cache when the underlying data changed without the "saveAsync" or "deleteAsync" methods involved. For instance, when the database where entities are stored was modified by another user.

--- a/lib/repository.d.ts
+++ b/lib/repository.d.ts
@@ -1,25 +1,25 @@
 import { DTOsMap, IOProvider, Ctor, FilterGroup } from "./types";
 export interface RepositoryReadonly<D extends DTOsMap, E extends keyof D> {
-    /** find one entity object with a specific id, throws exception if not found */
-    findAsync(id: string): Promise<D[E]["fromStorage"]>;
-    /** get entity objects with optional parent and additional filters ... */
-    getAsync(args: {
-        parentId: string;
-        filters?: FilterGroup<D[E]["fromStorage"]>;
-    }): Promise<D[E]["fromStorage"][]>;
+	/** find one entity object with a specific id, throws exception if not found */
+	findAsync(id: string): Promise<D[E]["fromStorage"]>;
+	/** get entity objects with optional parent and additional filters ... */
+	getAsync(args: {
+		parentId: string;
+		filters?: FilterGroup<D[E]["fromStorage"]>;
+	}): Promise<D[E]["fromStorage"][]>;
 }
 export interface RepositoryEditable<D extends DTOsMap, E extends keyof D> extends RepositoryReadonly<D, E> {
-    saveAsync: (obj: D[E]["toStorage"]) => Promise<D[E]["fromStorage"]>;
+	saveAsync: (obj: D[E]["toStorage"]) => Promise<D[E]["fromStorage"]>;
 }
 export interface Repository<D extends DTOsMap, E extends keyof D> extends RepositoryEditable<D, E> {
-    deleteAsync: (id: string) => Promise<void>;
+	deleteAsync: (id: string) => Promise<void>;
 }
 export declare type RepositoryGroup<D extends DTOsMap> = {
-    [key in keyof D]: Repository<D, Extract<keyof D, string>>;
+	[key in keyof D]: Repository<D, keyof D>;
 };
 /**
  *
  * @param ioProviderClass
  * @param repos The individual repositories: tables, users...
  */
-export declare function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoNames: Extract<keyof D, string>[]) => RepositoryGroup<D>;
+export declare function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoInfo: { [key in keyof D]: string }) => RepositoryGroup<D>;

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -1,69 +1,69 @@
 export declare type Obj<TValue = any, TKey extends string = string> = {
-    [key in TKey]: TValue;
+	[key in TKey]: TValue;
 };
 export declare type ExtractByType<TObj, TType> = Pick<TObj, {
-    [k in keyof TObj]-?: TObj[k] extends TType ? k : never;
+	[k in keyof TObj]-?: TObj[k] extends TType ? k : never;
 }[keyof TObj]>;
 export declare type Primitive = number | string;
 export interface Ctor<TArgs = {}, TObj = {}> {
-    new (args: TArgs): TObj;
+	new(args: TArgs): TObj;
 }
 declare type DTO = {
-    toStorage: Object & {
-        id?: string;
-    };
-    fromStorage: Object;
+	toStorage: Object & {
+		id?: string;
+	};
+	fromStorage: Object;
 };
 export declare type DTOsMap = {
-    [key: string]: DTO;
+	[key: string]: DTO;
 };
 export interface IOProvider<X = {}, D extends DTOsMap = DTOsMap> {
-    /** find one entity object, throws exception if not found */
-    findAsync: <E extends Extract<keyof D, string>>(args: {
-        entity: E;
-        id: string;
-    }) => Promise<D[E]["fromStorage"]>;
-    /** get a set of entity objects */
-    getAsync: <E extends Extract<keyof D, string>>(args: {
-        entity: E;
-        parentId?: string;
-        filters?: FilterGroup<D[E]["fromStorage"]>;
-    }) => Promise<D[E]["fromStorage"][]>;
-    saveAsync: <E extends Extract<keyof D, string>>(args: {
-        entity: E;
-        obj: D[E]["toStorage"];
-        mode: "insert" | "update";
-    }) => Promise<D[E]["fromStorage"]>;
-    deleteAsync: <E extends Extract<keyof D, string>>(args: {
-        entity: E;
-        id: string;
-    }) => Promise<void>;
-    extensions: X;
+	/** find one entity object, throws exception if not found */
+	findAsync: <E extends keyof D>(args: {
+		entity: E;
+		id: string;
+	}) => Promise<D[E]["fromStorage"]>;
+	/** get a set of entity objects */
+	getAsync: <E extends keyof D>(args: {
+		entity: E;
+		parentId?: string;
+		filters?: FilterGroup<D[E]["fromStorage"]>;
+	}) => Promise<D[E]["fromStorage"][]>;
+	saveAsync: <E extends keyof D>(args: {
+		entity: E;
+		obj: D[E]["toStorage"];
+		mode: "insert" | "update";
+	}) => Promise<D[E]["fromStorage"]>;
+	deleteAsync: <E extends keyof D>(args: {
+		entity: E;
+		id: string;
+	}) => Promise<void>;
+	extensions: X;
 }
 export declare namespace Filters {
-    interface Base<TObj extends Obj<Primitive>, TVal extends Primitive | null> {
-        fieldName: keyof (ExtractByType<TObj, TVal>);
-        value: TVal;
-        negated?: boolean;
-    }
-    interface Categorical<T extends Obj<Primitive>> extends Base<T, Primitive | null> {
-        operator: "equal" | "not_equal";
-    }
-    interface Ordinal<T extends Obj<Primitive>> extends Base<T, number> {
-        operator: "greater" | "greater_or_equal" | "less" | "less_or_equal";
-        negated?: boolean;
-    }
-    interface Textual<T extends Obj<Primitive>> extends Base<T, string> {
-        operator: "contains" | "starts_with" | "ends_with";
-    }
-    interface Statistical<T extends Obj<Primitive>> extends Base<T, number> {
-        operator: "is_outlier_by";
-    }
+	interface Base<TObj extends Obj<Primitive>, TVal extends Primitive | null> {
+		fieldName: keyof (ExtractByType<TObj, TVal>);
+		value: TVal;
+		negated?: boolean;
+	}
+	interface Categorical<T extends Obj<Primitive>> extends Base<T, Primitive | null> {
+		operator: "equal" | "not_equal";
+	}
+	interface Ordinal<T extends Obj<Primitive>> extends Base<T, number> {
+		operator: "greater" | "greater_or_equal" | "less" | "less_or_equal";
+		negated?: boolean;
+	}
+	interface Textual<T extends Obj<Primitive>> extends Base<T, string> {
+		operator: "contains" | "starts_with" | "ends_with";
+	}
+	interface Statistical<T extends Obj<Primitive>> extends Base<T, number> {
+		operator: "is_outlier_by";
+	}
 }
 declare type Filter<T extends Obj<Primitive> = Obj<Primitive>> = (Filters.Categorical<T> | Filters.Ordinal<T> | Filters.Textual<T> | Filters.Statistical<T>);
 export interface FilterGroup<T extends Obj = Obj> {
-    /** combinator default is "and" */
-    combinator?: "or" | "and";
-    filters: (Filter<T> | FilterGroup<T>)[];
+	/** combinator default is "and" */
+	combinator?: "or" | "and";
+	filters: (Filter<T> | FilterGroup<T>)[];
 }
-export {};
+export { };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
 	},
 	"dependencies": {
 		"@sparkwave/standard": "^2.5.0",
+		"@types/pluralize": "0.0.29",
 		"@types/shortid": "0.0.29",
+		"pluralize": "^8.0.0",
 		"shortid": "^2.2.15"
 	}
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -24,11 +24,14 @@ export type RepositoryGroup<D extends DTOsMap> = {
 	[key in keyof D]: Repository<D, keyof D>
 }
 
+/** Each entity has an entry: key is the entity name, value is the entity parent's name (empty string if no parent) */
+type DTOInfo<D extends DTOsMap> = { [key in keyof D]: string }
+
 /** Generates a repository group from the io provider
  * @param ioProviderClass 
  * @param repos The individual repositories: tables, users...
  */
-export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoInfo: { [key in keyof D]: string }, cached: boolean) => RepositoryGroup<D> {
+export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoInfo: DTOInfo<D>, cached: boolean) => RepositoryGroup<D> {
 	type DTOIndex = keyof D
 	return class {
 		[key: string]: any

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,6 +1,6 @@
 
 import { singular } from "pluralize"
-import { FilterGroup } from "@sparkwave/standard"
+import { FilterGroup, Dictionary, Obj } from "@sparkwave/standard"
 import { DTOsMap, IOProvider, Ctor, CacheEntry, EntityCache } from "./types"
 
 export interface RepositoryReadonly<D extends DTOsMap, E extends keyof D> {
@@ -38,7 +38,8 @@ export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOP
 		constructor(config: object, dtoInfo: { [key in keyof D]: string }, cached: boolean) {
 			try {
 				this.io = new ioProviderClass({ ...config })
-				this.cache = cached === true ? {} as EntityCache<D> : undefined
+				const emptyCache = Dictionary.fromKeyValues(Object.keys(dtoInfo).map(key => [key, [] as CacheEntry<D, keyof D>[]])).asObject() as EntityCache<D>
+				this.cache = cached === true ? emptyCache : undefined
 			}
 			catch (err) {
 				throw new Error(`Repository group constructor : ${err} `)

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -1,102 +1,140 @@
 
+import { singular } from "pluralize"
 import { FilterGroup } from "@sparkwave/standard"
 import { DTOsMap, IOProvider, Ctor, CacheEntry } from "./types"
 
-export interface RepositoryReadonly<D extends DTOsMap, E extends Extract<keyof D, "string">> {
+export interface RepositoryReadonly<D extends DTOsMap, E extends keyof D> {
 	/** find one entity object with a specific id, throws exception if not found */
 	findAsync(id: string): Promise<D[E]["fromStorage"]>
 
 	/** get entity objects with optional parent and additional filters ... */
 	getAsync(args: { parentId: string, filters?: FilterGroup<D[E]["fromStorage"]> }): Promise<D[E]["fromStorage"][]>
-	/** A reference to the cache of the RepositoryGroup */
-	cache: CacheEntry<D>[]
+
 	/** A method to remove an entry from the cache */
-	bustCache?(entry: CacheEntry<D>): () => void
+	bustCache(entry: CacheEntry<D>): () => void
 }
-export interface RepositoryEditable<D extends DTOsMap, E extends Extract<keyof D, "string">> extends RepositoryReadonly<D, E> {
+export interface RepositoryEditable<D extends DTOsMap, E extends keyof D> extends RepositoryReadonly<D, E> {
 	saveAsync: (obj: D[E]["toStorage"][]) => Promise<D[E]["fromStorage"][]>
 }
-export interface Repository<D extends DTOsMap, E extends Extract<keyof D, "string">> extends RepositoryEditable<D, E> {
+export interface Repository<D extends DTOsMap, E extends keyof D> extends RepositoryEditable<D, E> {
 	deleteAsync: (id: string) => Promise<D[E]["fromStorage"]>
 	deleteManyAsync?: (args: { parentId: string } | { ids: string[] }) => Promise<D[E]["fromStorage"][]>
 }
 export type RepositoryGroup<D extends DTOsMap> = {
-	[key in Extract<keyof D, "string">]: Repository<D, Extract<keyof D, "string">>
-} & { cache?: CacheEntry<D>[] }
+	[key in keyof D]: Repository<D, keyof D>
+}
 
 /** Generates a repository group from the io provider
  * @param ioProviderClass 
  * @param repos The individual repositories: tables, users...
  */
-export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoNames: (Extract<keyof D, "string">)[], cache?: CacheEntry<D>[]) => RepositoryGroup<D> {
+export function generate<X, D extends DTOsMap>(ioProviderClass: Ctor<object, IOProvider<X, D>>): new (config: object, dtoInfo: { [key in keyof D]: string }, cached: boolean) => RepositoryGroup<D> {
+	type DTOIndex = keyof D
 	return class {
 		[key: string]: any
 		readonly io: Readonly<IOProvider<X>>
 		cache?: CacheEntry<D>[]
 
-		constructor(config: object, dtoNames: (Extract<keyof D, "string">)[], cache?: CacheEntry<D>[]) {
+		constructor(config: object, dtoInfo: { [key in keyof D]: string }, cached: boolean) {
 			try {
-				this.io = new ioProviderClass({ ...config, cache: cache })
-				this.cache = cache
+				this.io = new ioProviderClass({ ...config })
+				this.cache = cached === true ? [] : undefined
 			}
 			catch (err) {
 				throw new Error(`Repository group constructor : ${err} `)
 			}
 			console.assert(this.io !== undefined, `Repository group this.io after construction is still undefined`)
-			dtoNames.forEach(prop => {
-				this[prop as string] = this.createRepository(prop, this.cache) as Repository<D, typeof prop>
+			Object.keys(dtoInfo).forEach(dtoName => {
+				this[dtoName] = this.createRepository({ name: dtoName as DTOIndex, parentName: dtoInfo[dtoName] as DTOIndex })
 			})
 		}
-		protected createRepository<E extends Extract<keyof D, "string">>(e: E, cache?: CacheEntry<D>[]) {
+		protected createRepository<E extends Extract<keyof D, "string">>(dto: { name: DTOIndex, parentName: DTOIndex }) {
 			return {
 				findAsync: async (id: string) => {
 					if (this.cache !== undefined) {
 						if (this.cache.find(entry => entry.type === "single" && entry.key === id) === undefined) {
-							this.cache.push({ type: "single", key: id, content: this.io.findAsync({ entity: e, id: id }) })
+							this.cache.push({ type: "single", key: id, content: this.io.findAsync({ entity: dto.name as string, id: id }) })
 						}
 						return this.cache.find(entry => entry.type === "single" && entry.key === id)?.content
 					} else {
-						return this.io.findAsync({ entity: e, id: id })
+						return this.io.findAsync({ entity: dto.name as string, id: id })
 					}
 				},
 				getAsync: async (selector: { parentId?: string, filters?: FilterGroup<D[E]["fromStorage"]> }) => {
-					if (this.cache) {
+					if (this.cache !== undefined) {
 						if (this.cache.find(entry => entry.type === "multiple"
-							&& entry.keys.entity === e
+							&& entry.keys.entity === dto.name
 							&& entry.keys.parentId === selector.parentId
 							&& entry.keys.filters === JSON.stringify(selector.filters)
 						) === undefined) {
 							this.cache.push({
 								type: "multiple",
-								keys: { entity: e, parentId: selector.parentId || "", filters: JSON.stringify(selector.filters) },
-								content: this.io.getAsync({ entity: e, parentId: selector?.parentId, filters: selector?.filters })
+								keys: { entity: dto.name, parentId: selector.parentId || "", filters: JSON.stringify(selector.filters) },
+								content: this.io.getAsync({ entity: dto.name as string, parentId: selector?.parentId, filters: selector?.filters })
 							})
 						}
 						return this.cache.find(entry => entry.type === "multiple"
-							&& entry.keys.entity === e
+							&& entry.keys.entity === dto.name
 							&& entry.keys.parentId === selector.parentId
 							&& entry.keys.filters === JSON.stringify(selector.filters)
 						)?.content
 					}
 					else {
-						return this.io.getAsync({ entity: e, parentId: selector?.parentId, filters: selector?.filters })
+						return this.io.getAsync({ entity: dto.name as string, parentId: selector?.parentId, filters: selector?.filters })
 					}
 				},
 				saveAsync: async (obj: D[E]["toStorage"][]) => {
-					return obj[0].id
-						? this.io.saveAsync({ entity: e, obj: obj, mode: "update" })
-						: this.io.saveAsync({ entity: e, obj: obj, mode: "insert" })
+					const resultPromise = obj[0].id
+						? this.io.saveAsync({ entity: dto.name as string, obj: obj, mode: "update" })
+						: this.io.saveAsync({ entity: dto.name as string, obj: obj, mode: "insert" })
+
+					resultPromise.then(results => {
+						results.forEach(result => {
+							// We invalidate the findAsync cache of all entities with that id (so that updates work)
+							result.id !== undefined ? this.bustCache({ type: "single", key: result.id }) : undefined
+
+							// We invalidate all getAsync cache entries for entities with the same parent (when adding a table, the getTable of that project will be refreshed)
+							const effectiveParentId = dto.parentName !== "" ? result[`${dto.parentName}Id`].toString() : ""
+							this.bustCache({ type: "multiple", keys: { entity: dto.name, parentId: effectiveParentId } })
+						})
+					})
+					return resultPromise
 				},
-				deleteAsync: async (id: string) => this.io.deleteAsync({ entity: e, id: id }),
+				deleteAsync: async (id: string) => {
+					const deletedEntity = await this.io.deleteAsync({ entity: dto.name as string, id: id })
+					// We invalidate the findAsync cache of all entities with that id (so that updates work)
+					this.bustCache({ type: "single", key: id })
+
+					// We invalidate all getAsync cache entries for entities with the same parent (when adding a table, the getTable of that project will be refreshed)
+					const effectiveParentId = dto.parentName !== "" ? deletedEntity[`${singular(dto.parentName as string)}Id`].toString() : ""
+					this.bustCache({ type: "multiple", keys: { entity: dto.name, parentId: effectiveParentId } })
+					return deletedEntity
+				},
 				deleteManyAsync: async (args: { parentId: string } | { ids: string[] }) => this.io.deleteManyAsync
 					? this.io.deleteManyAsync({
-						entity: e,
+						entity: dto.name as string,
 						..."parentId" in args
 							? { parentId: args["parentId"] }
 							: { ids: args["ids"] }
 					})
 					: undefined,
-				cache: cache
+				bustCache: (entryToBust: CacheEntry<D>) => {
+					if (this.cache) {
+						const entries = [...this.cache]
+						this.cache.length = 0
+
+						entries.filter(entry => {
+							if (entryToBust.type === "single") {
+								return !(entry.type === "single" && entry.key === entryToBust.key)
+							}
+							else {
+								return !(entry.type === "multiple"
+									&& entry.keys.entity === entryToBust.keys.entity
+									&& entry.keys.parentId === entryToBust.keys.parentId)
+							}
+						}).forEach(entry => this.cache!.push(entry))
+					}
+				}
 			} as Repository<D, E>
 		}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,18 +8,20 @@ type DTO = {
 }
 export type DTOsMap = { [key: string]: DTO }
 
-export type CacheEntry<D extends DTOsMap> = (
+export type CacheEntry<M extends DTOsMap, E extends keyof M> = (
 	| {
 		type: "single"
-		key: string,
-		content?: Promise<D[keyof D]["fromStorage"]>
+		entityId: string,
+		content?: Promise<M[E]["fromStorage"]>
 	}
 	| {
 		type: "multiple"
-		keys: { entity: keyof D, parentId: string, filters?: string },
-		content?: Promise<D[keyof D]["fromStorage"][]>
+		parentEntityId: string,
+		filters?: string,
+		content?: Promise<M[E]["fromStorage"][]>
 	}
 )
+export type EntityCache<M extends DTOsMap> = { [k in keyof M]: CacheEntry<M, k>[] }
 
 export interface IOProvider<X = {}, D extends DTOsMap = DTOsMap> {
 	/** find one entity object, throws exception if not found */


### PR DESCRIPTION
Resolves #29 

**Merge message:**
- Kept the cache as an internal object of the RepositoryGroup, not exposed to the outside
- Implemented an automated cache invalidation upon saving/deleting entities: the user doesn't need to set it up in the io provider.
- Added a "bustCache" function to the exposed methods of each repository: it permits additional invalidation besides the automated ones: for instance when receiving external information that the entities changed.
- Turned the constructor argument into a key-value object that includes the entity name as key, and parent name as value (we might need the parent's name for cache purpose)
- Added a readme explanation of the cache system