### PR TITLE
PR: Allow the get and find methods to bypass the cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		"typescript": "^4.0.5"
 	},
 	"dependencies": {
-		"@sparkwave/standard": "2.27.0",
+		"@sparkwave/standard": "^2.29.1",
 		"shortid": "^2.2.15"
 	}
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -121,7 +121,7 @@ export function repositoryGroupFactory<S extends Schema, Cfg extends Obj | void 
 
 							deleteAsync: async (id) => {
 								if (ioProvider) {
-									ioProvider.deleteAsync({ entity: e, id })
+									await ioProvider.deleteAsync({ entity: e, id })
 								}
 								_cache[e].vectors = {}
 								delete _cache[e].objects[String(id)]

--- a/src/core.ts
+++ b/src/core.ts
@@ -47,9 +47,9 @@ export function repositoryGroupFactory<S extends Schema, Cfg extends Obj | void 
 					(entry === undefined) || (new Date().getTime() - entry[1] > CACHE_EXPIRATION_MILLISECONDS)
 
 				return {
-					findAsync: async (id) => {
+					findAsync: async (id, refreshCache?: boolean) => {
 						const objects = _cache[e].objects
-						if (ioProvider && invalidOrStale(objects[id])) {
+						if (ioProvider && (invalidOrStale(objects[id]) || refreshCache)) {
 							// eslint-disable-next-line fp/no-mutation
 							objects[id] = new Tuple(
 								await ioProvider.findAsync({ entity: e, id: id }),
@@ -59,11 +59,11 @@ export function repositoryGroupFactory<S extends Schema, Cfg extends Obj | void 
 						return objects[id][0]
 					},
 
-					getAsync: async (filter) => {
+					getAsync: async (filter, refreshCache?: boolean) => {
 						const filtersKey = filter ? JSON.stringify(filter) : "N/A"
 						const vectors = _cache[e].vectors
 						if (ioProvider) {
-							if (invalidOrStale(vectors[filtersKey])) {
+							if (invalidOrStale(vectors[filtersKey]) || refreshCache) {
 								vectors[filtersKey] = [
 									ioProvider.getAsync({ entity: e, filters: filter }),
 									new Date().getTime()

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -84,12 +84,15 @@ export interface IOProvider<S extends Schema, X extends Obj = Obj> {
 
 export interface RepositoryReadonly<T extends Obj> {
 	/** Get one entity object with a specific id from underlying data-source
-	 * Throws exception if not found
+	 ** Throws exception if not found.
+	 ** If refreshCache is true, a new object will be queried from the data-source even if a cache entry already exists (for instance, if the data-source changed through another mean than the repository methods)
 	 */
-	findAsync(id: string): Promise<T>
+	findAsync(id: string, refreshCache?: boolean): Promise<T>
 
-	/** Get entity objects from underlying data-source with optional filters ... */
-	getAsync(filters?: FilterGroup<T>): Promise<T[]>
+	/** Get entity objects from underlying data-source with optional filters...
+	 ** If refreshCache is true, new objects will be queried from the data-source even if a cache entry already exists (for instance, if the data-source changed through another mean than the repository methods)
+	 */
+	getAsync(filters?: FilterGroup<T>, refreshCache?: boolean): Promise<T[]>
 }
 export interface Repository<T extends Obj /*& { id: string | number }*/> extends RepositoryReadonly<T> {
 	/** Insert one or more entity objects in underlying data source

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -92,7 +92,7 @@ export interface RepositoryReadonly<T extends Obj> {
 	/** Get entity objects from underlying data-source with optional filters...
 	 ** If refreshCache is true, new objects will be queried from the data-source even if a cache entry already exists (for instance, if the data-source changed through another mean than the repository methods)
 	 */
-	getAsync(filters?: FilterGroup<T>, refreshCache?: boolean): Promise<T[]>
+	getAsync(filters?: FilterGroup, refreshCache?: boolean): Promise<T[]>
 }
 export interface Repository<T extends Obj /*& { id: string | number }*/> extends RepositoryReadonly<T> {
 	/** Insert one or more entity objects in underlying data source


### PR DESCRIPTION
**Title:**
fix: (#40) Allow repository methods to bypass cache

**Merge message:**
Resolves #40

- Added a "refreshCache" argument to the getAsync and findAsync method of the repositories created by the RepositoryGroupFactory. It indicates that even if a cache entry exist for the required entities, it should be fetched again from the io provider, and the cache should be refreshed with this updated result.
- Added an "await" keyword when calling an io provider's deleteAsync method, ensuring that the repository's deleteAsync method only returns after the io provider's deletion method returned.