### PR TITLE
PR: Enable type check of schema object properties

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -35,11 +35,11 @@ export type PrimitiveFieldType<F extends PrimitiveField> = (F extends { type: Pr
 )*/
 export declare type ObjectFieldType<F extends ObjectField> = (F extends "object"
 	? Obj
-	: F extends { type: "object"; valueType: PrimitiveField; nullable?: boolean; }
+	: F extends { type: "object", valueType: PrimitiveField, nullable?: boolean }
 	? NullableType<PrimitiveFieldType<F["valueType"]>, F["nullable"]>
-	: F extends { type: "object"; valueType: ArrayField; nullable?: boolean; }
+	: F extends { type: "object", valueType: ArrayField, nullable?: boolean }
 	? ArrayFieldType<F["valueType"]>
-	: F extends { type: "object"; valueType: Obj<Field>; nullable?: boolean; }
+	: F extends { type: "object", valueType: Obj<Field>, nullable?: boolean }
 	? NullableType<{ [k in keyof F["valueType"]]?: FieldType<F["valueType"][k]> }, F["nullable"]>
 	: never
 )

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,16 +33,22 @@ export type PrimitiveFieldType<F extends PrimitiveField> = (F extends { type: Pr
 	? PrimitiveType<F>
 	: never
 )*/
-export type ObjectFieldType<F extends ObjectField> = (F extends "object"
-	? Obj
-	: F extends { type: "object", valueType: PrimitiveField, nullable?: boolean }
-	? NullableType<PrimitiveFieldType<F["valueType"]>, F["nullable"]>
-	: F extends { type: "object", valueType: ArrayField, nullable?: boolean }
-	? ArrayFieldType<F["valueType"]>
-	: F extends { type: "object", valueType: ObjectField, nullable?: boolean }
-	? Obj<Obj>
+export declare type ObjectFieldType<F extends ObjectField> = (F extends "object" ? Obj : F extends {
+	type: "object";
+	valueType: PrimitiveField;
+	nullable?: boolean;
+} ? NullableType<PrimitiveFieldType<F["valueType"]>, F["nullable"]> : F extends {
+	type: "object";
+	valueType: ArrayField;
+	nullable?: boolean;
+} ? ArrayFieldType<F["valueType"]> : F extends {
+	type: "object";
+	valueType: Obj<Field>;
+	nullable?: boolean;
+} ? NullableType<{ [k in keyof F["valueType"]]?: FieldType<F["valueType"][k]> }, F["nullable"]>
 	: never
 )
+
 export type ArrayFieldType<F extends ArrayField> = (F extends "array"
 	? unknown[]
 	: F extends { type: "array", arrayType: Field, nullable?: boolean }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,19 +33,14 @@ export type PrimitiveFieldType<F extends PrimitiveField> = (F extends { type: Pr
 	? PrimitiveType<F>
 	: never
 )*/
-export declare type ObjectFieldType<F extends ObjectField> = (F extends "object" ? Obj : F extends {
-	type: "object";
-	valueType: PrimitiveField;
-	nullable?: boolean;
-} ? NullableType<PrimitiveFieldType<F["valueType"]>, F["nullable"]> : F extends {
-	type: "object";
-	valueType: ArrayField;
-	nullable?: boolean;
-} ? ArrayFieldType<F["valueType"]> : F extends {
-	type: "object";
-	valueType: Obj<Field>;
-	nullable?: boolean;
-} ? NullableType<{ [k in keyof F["valueType"]]?: FieldType<F["valueType"][k]> }, F["nullable"]>
+export declare type ObjectFieldType<F extends ObjectField> = (F extends "object"
+	? Obj
+	: F extends { type: "object"; valueType: PrimitiveField; nullable?: boolean; }
+	? NullableType<PrimitiveFieldType<F["valueType"]>, F["nullable"]>
+	: F extends { type: "object"; valueType: ArrayField; nullable?: boolean; }
+	? ArrayFieldType<F["valueType"]>
+	: F extends { type: "object"; valueType: Obj<Field>; nullable?: boolean; }
+	? NullableType<{ [k in keyof F["valueType"]]?: FieldType<F["valueType"][k]> }, F["nullable"]>
 	: never
 )
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,3 +136,43 @@ export type EntityCacheGroup<S extends Schema> = {
 		vectors: Obj<[vector: Promise<T<S, e>[]>, timeStamp: number], FilterKey>
 	}
 }
+
+
+/**
+ * TYPING TESTS
+ */
+
+const testSchema = {
+	testEntity: {
+		fields: {
+			requiredNumber: "number",
+			optionalNumber: { type: "number", nullable: true },
+			textual: "string",
+			generalObject: "object",
+			specificObject: { type: "object", valueType: { numerical: "number", textual: "string" } },
+			generalArray: "array",
+			arrayOfNumber: { type: "array", arrayType: "number" },
+		},
+		readonly: true,
+		idField: "id"
+	}
+} as const
+
+export type DbSchema = typeof testSchema
+
+type TestEntityType = EntityType<typeof testSchema["testEntity"]>
+
+const TestEntity: TestEntityType = {
+	requiredNumber: 67,
+	optionalNumber: undefined,
+	textual: "Ha",
+	generalObject: { random: "Ha", anotherProp: 67 },
+	specificObject: { numerical: 9, textual: "Ha" },
+	generalArray: [null, 6, "Blue"],
+	arrayOfNumber: [9]
+}
+
+// Failing
+// const wrongSpecificObject: TestEntityType["specificObject"] = { wrongProp: 56 }
+// const wrongSpecificArray: TestEntityType["arrayOfNumber"] = ["Blue"]
+// const absentRequiredProp: TestEntityType["requiredNumber"] = undefined

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ export type PrimitiveFieldType<F extends PrimitiveField> = (F extends { type: Pr
 	? PrimitiveType<F>
 	: never
 )*/
-export declare type ObjectFieldType<F extends ObjectField> = (F extends "object"
+export type ObjectFieldType<F extends ObjectField> = (F extends "object"
 	? Obj
 	: F extends { type: "object", valueType: PrimitiveField, nullable?: boolean }
 	? NullableType<PrimitiveFieldType<F["valueType"]>, F["nullable"]>
@@ -43,7 +43,6 @@ export declare type ObjectFieldType<F extends ObjectField> = (F extends "object"
 	? NullableType<{ [k in keyof F["valueType"]]?: FieldType<F["valueType"][k]> }, F["nullable"]>
 	: never
 )
-
 export type ArrayFieldType<F extends ArrayField> = (F extends "array"
 	? unknown[]
 	: F extends { type: "array", arrayType: Field, nullable?: boolean }


### PR DESCRIPTION
**Title:**
feat: (#44) Enable type check of schema object properties

**Merge message:**
Updated the type "ObjectFieldType", so that when an object is declared in a schema, it's properties will be required in the actual TS type (currently they are not, any object of type "Obj" will be considered valid)

Resolves #40